### PR TITLE
Add startup script and normalize model paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,25 +30,18 @@ pip install -r requirements.txt
 ## 快速开始
 
 1. 安装依赖：`pip install -r requirements.txt`
-2. 分别启动各项服务：
+2. 启动所有 gRPC 服务与编排器：
 
    ```bash
-   python -m services.vad.server
-   python -m services.denoise.server
-   python -m services.lid.server
-   python -m services.compress.server
+   ./start.sh
    ```
-   首次启动 VAD 与 LID 服务会自动将模型下载到仓库的 `models/` 目录。
-3. 启动编排器 WebSocket 服务：
-
-   ```bash
-   python -m orchestrator.server_ws
-   ```
-4. 运行示例客户端，将本地 `16k PCM` 流发送到编排器：
+   每个服务的标准输出和错误日志将分别写入 `vad.out`、`denoise.out`、`lid.out`、`compress.out` 和 `server.out`，便于排查问题。若需要更详细日志，可设置环境变量 `LOG_LEVEL=DEBUG` 后再运行。
+3. 运行示例客户端，将本地 `16k PCM` 流发送到 VAD 服务：
 
    ```bash
    PYTHONPATH=. python tests/send_only.py
    ```
+   首次启动 VAD 与 LID 服务会自动将模型下载到仓库的 `models/` 目录。
 
 ## 当前进度
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,9 @@
+"""Central port configuration for services and clients."""
+import os
+
+VAD_PORT = int(os.environ.get("VAD_PORT", "9001"))
+DENOISE_PORT = int(os.environ.get("DENOISE_PORT", "50053"))
+LID_PORT = int(os.environ.get("LID_PORT", "50052"))
+COMPRESS_PORT = int(os.environ.get("COMPRESS_PORT", "50054"))
+ORCHESTRATOR_PORT = int(os.environ.get("ORCHESTRATOR_PORT", "8000"))
+ASR_PORT = int(os.environ.get("ASR_PORT", "50051"))

--- a/config.py
+++ b/config.py
@@ -1,4 +1,5 @@
-"""Central port configuration for services and clients."""
+"""Central configuration for ports and logging."""
+import logging
 import os
 
 VAD_PORT = int(os.environ.get("VAD_PORT", "9001"))
@@ -7,3 +8,13 @@ LID_PORT = int(os.environ.get("LID_PORT", "50052"))
 COMPRESS_PORT = int(os.environ.get("COMPRESS_PORT", "50054"))
 ORCHESTRATOR_PORT = int(os.environ.get("ORCHESTRATOR_PORT", "8000"))
 ASR_PORT = int(os.environ.get("ASR_PORT", "50051"))
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+LOG_FORMAT = os.environ.get(
+    "LOG_FORMAT", "%(asctime)s %(levelname)s [%(name)s] %(message)s"
+)
+
+
+def configure_logging() -> None:
+    """Configure root logger according to environment variables."""
+    logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT)

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -3,22 +3,7 @@
 该目录提供一个最小可用的音频编排器示例，通过 WebSocket 接收 PCM16 音频数据，内部串联 VAD/降噪/LID/压缩/ASR，并将结果回推给客户端。
 
 ## 启动依赖服务
-
-在运行编排器之前，需要先启动各个 gRPC 服务：
-
-```bash
-# 语音活动检测
-python -m services.vad.server
-
-# 空壳降噪
-python -m services.denoise.server
-
-# 语种识别
-python -m services.lid.server
-
-# PCM→Opus 压缩
-python -m services.compress.server
-```
+可以通过仓库根目录的 `start.sh` 一键启动 VAD、降噪、LID、压缩及编排器，并把日志分别写入对应的 `*.out` 文件。
 
 ## 使用流程
 
@@ -39,6 +24,12 @@ python -m services.compress.server
 
 3. **事件返回**
    服务端会通过文本帧返回 `ack` / `lid` / `asr_partial` / `asr_final` / `end` 等事件。
+
+   仓库提供了 `tests/send_to_orchestrator.py` 作为示例客户端，可用于快速验证：
+
+   ```bash
+   PYTHONPATH=. python tests/send_to_orchestrator.py --ws ws://127.0.0.1:9000/ws/stream --input tests/test.wav
+   ```
 
 ## 注意事项
 

--- a/orchestrator/modules/asr_client.py
+++ b/orchestrator/modules/asr_client.py
@@ -1,10 +1,13 @@
 """gRPC client for streaming ASR service."""
 
 import asyncio
+import logging
 import grpc
 
 from config import ASR_PORT
 from ..protos import asr_pb2, asr_pb2_grpc
+
+logger = logging.getLogger(__name__)
 
 
 class AsrClient:
@@ -28,7 +31,7 @@ class AsrClient:
             await self.stream.done_writing()
             async for evt in self.stream:
                 # In real implementation the result would be forwarded.
-                print("ASR result:", evt)
+                logger.info("ASR result: %s", evt)
 
     def close(self) -> None:
         if self.channel:

--- a/orchestrator/modules/asr_client.py
+++ b/orchestrator/modules/asr_client.py
@@ -2,11 +2,13 @@
 
 import asyncio
 import grpc
+
+from config import ASR_PORT
 from ..protos import asr_pb2, asr_pb2_grpc
 
 
 class AsrClient:
-    def __init__(self, flow_id: str, target: str = "asr:50051") -> None:
+    def __init__(self, flow_id: str, target: str = f"asr:{ASR_PORT}") -> None:
         self.flow_id = flow_id
         self.channel = grpc.aio.insecure_channel(target)
         self.stub = asr_pb2_grpc.RecognizeStub(self.channel)

--- a/orchestrator/modules/asr_client.py
+++ b/orchestrator/modules/asr_client.py
@@ -22,6 +22,7 @@ class AsrClient:
             self.stream = self.stub.Stream()
             start = asr_pb2.Start(flow_id=self.flow_id, codec="opus", sr=16000, language=language)
             await self.stream.write(asr_pb2.ClientFrame(start=start))
+        logger.debug("[%s] ASR send %d bytes", self.flow_id, len(opus_pkt))
         await self.stream.write(
             asr_pb2.ClientFrame(opus=asr_pb2.OpusPacket(data=opus_pkt))
         )
@@ -30,9 +31,8 @@ class AsrClient:
         if self.stream:
             await self.stream.done_writing()
             async for evt in self.stream:
-                # In real implementation the result would be forwarded.
-                logger.info("ASR result: %s", evt)
-
+                logger.info("[%s] ASR result: %s", self.flow_id, evt)
+            
     def close(self) -> None:
         if self.channel:
             self.channel.close()

--- a/orchestrator/modules/compress_client.py
+++ b/orchestrator/modules/compress_client.py
@@ -3,11 +3,13 @@
 import asyncio
 import numpy as np
 import grpc
+
+from config import COMPRESS_PORT
 from services.compress.protos import compress_pb2, compress_pb2_grpc  # type: ignore
 
 
 class CompressClient:
-    def __init__(self, target: str = "localhost:50054") -> None:
+    def __init__(self, target: str = f"localhost:{COMPRESS_PORT}") -> None:
         self.channel = grpc.aio.insecure_channel(target)
         self.stub = compress_pb2_grpc.CompressStub(self.channel)
         self.frame_samples = 16000 * 20 // 1000

--- a/orchestrator/modules/compress_client.py
+++ b/orchestrator/modules/compress_client.py
@@ -1,11 +1,14 @@
 """gRPC client for PCM→Opus compression."""
 
 import asyncio
+import logging
 import numpy as np
 import grpc
 
-from config import COMPRESS_PORT
+from config import COMPRESS_PORT, configure_logging
 from services.compress.protos import compress_pb2, compress_pb2_grpc  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 
 class CompressClient:
@@ -33,9 +36,10 @@ class CompressClient:
 if __name__ == "__main__":
     async def _test():
         import os
+        configure_logging()
         cc = CompressClient()
         pcm = os.urandom(320 * 2)  # dummy 20ms
         out = await cc.encode(pcm)
-        print("encoded packets", len(out))
+        logger.info("encoded packets %s", len(out))
         cc.close()
     asyncio.run(_test())

--- a/orchestrator/modules/compress_client.py
+++ b/orchestrator/modules/compress_client.py
@@ -18,6 +18,7 @@ class CompressClient:
         self.frame_samples = 16000 * 20 // 1000
 
     async def encode(self, pcm_bytes: bytes) -> list[bytes]:
+        logger.debug("compress %d bytes", len(pcm_bytes))
         pcm = np.frombuffer(pcm_bytes, dtype=np.int16)
         packets: list[bytes] = []
         for i in range(0, len(pcm), self.frame_samples):
@@ -27,6 +28,7 @@ class CompressClient:
             req = compress_pb2.PCM(data=frame.tobytes())
             resp = await self.stub.Encode(req)
             packets.append(resp.data)
+        logger.debug("compress -> %d packets", len(packets))
         return packets
 
     def close(self) -> None:

--- a/orchestrator/modules/denoise_client.py
+++ b/orchestrator/modules/denoise_client.py
@@ -1,9 +1,12 @@
 """gRPC client for denoising service."""
 
+import logging
 import grpc
 
 from config import DENOISE_PORT
 from services.denoise.protos import denoise_pb2, denoise_pb2_grpc  # type: ignore
+
+logger = logging.getLogger(__name__)
 
 
 class DenoiseClient:
@@ -12,8 +15,10 @@ class DenoiseClient:
         self.stub = denoise_pb2_grpc.DenoiseStub(self.channel)
 
     async def send(self, pcm_bytes: bytes) -> bytes:
+        logger.debug("denoise send %d bytes", len(pcm_bytes))
         request = denoise_pb2.Audio(pcm=pcm_bytes, sample_rate=16000)
         response = await self.stub.Clean(request)
+        logger.debug("denoise recv %d bytes", len(response.pcm))
         return response.pcm
 
     def close(self) -> None:

--- a/orchestrator/modules/denoise_client.py
+++ b/orchestrator/modules/denoise_client.py
@@ -1,11 +1,13 @@
 """gRPC client for denoising service."""
 
 import grpc
+
+from config import DENOISE_PORT
 from services.denoise.protos import denoise_pb2, denoise_pb2_grpc  # type: ignore
 
 
 class DenoiseClient:
-    def __init__(self, target: str = "localhost:50053") -> None:
+    def __init__(self, target: str = f"localhost:{DENOISE_PORT}") -> None:
         self.channel = grpc.aio.insecure_channel(target)
         self.stub = denoise_pb2_grpc.DenoiseStub(self.channel)
 

--- a/orchestrator/modules/lid_client.py
+++ b/orchestrator/modules/lid_client.py
@@ -1,11 +1,13 @@
 """gRPC client for language identification."""
 
 import grpc
+
+from config import LID_PORT
 from services.lid.protos import lid_pb2, lid_pb2_grpc  # type: ignore
 
 
 class LidClient:
-    def __init__(self, flow_id: str, target: str = "localhost:50052") -> None:
+    def __init__(self, flow_id: str, target: str = f"localhost:{LID_PORT}") -> None:
         self.flow_id = flow_id
         self.channel = grpc.aio.insecure_channel(target)
         self.stub = lid_pb2_grpc.LIDStub(self.channel)

--- a/orchestrator/modules/vad_client.py
+++ b/orchestrator/modules/vad_client.py
@@ -3,11 +3,12 @@
 import asyncio
 import grpc
 
+from config import VAD_PORT
 from services.vad.protos import vad_pb2, vad_pb2_grpc
 
 
 class VadClient:
-    def __init__(self, target: str = "localhost:9001", flow_id: str = "default"):
+    def __init__(self, target: str = f"localhost:{VAD_PORT}", flow_id: str = "default"):
         self.flow_id = flow_id
         self.channel = grpc.aio.insecure_channel(target)
         self.stub = vad_pb2_grpc.VoiceActivityStub(self.channel)

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -29,30 +29,41 @@ class Orchestrator:
     async def feed_pcm(self, flow_id: str, pcm_bytes: bytes, ws) -> None:
         """Process raw PCM: VAD -> Denoise -> LID (buffer only)."""
         if flow_id not in self.sessions:
+            logger.warning("[%s] feed on unknown session", flow_id)
             return
         sess = self.sessions[flow_id]
+        logger.debug("[%s] recv %d bytes", flow_id, len(pcm_bytes))
         vad_out = await sess["vad"].send(pcm_bytes)
+        logger.debug("[%s] vad -> %d bytes", flow_id, len(vad_out))
         if not vad_out:
             return
         pcm_clean = await sess["denoise"].send(vad_out)
+        logger.debug("[%s] denoise -> %d bytes", flow_id, len(pcm_clean))
         sess["lid"].feed(pcm_clean)
         sess["buffer"].extend(pcm_clean)
+        logger.debug("[%s] buffer %d bytes", flow_id, len(sess["buffer"]))
 
     async def flush(self, flow_id: str) -> None:
         """Flush remaining audio, detect language, and stream to ASR."""
         sess = self.sessions.get(flow_id)
         if not sess:
             return
+        logger.info("[%s] flush with %d buffered bytes", flow_id, len(sess["buffer"]))
         vad_tail = await sess["vad"].flush()
+        logger.debug("[%s] vad tail %d bytes", flow_id, len(vad_tail))
         if vad_tail:
             pcm_clean = await sess["denoise"].send(vad_tail)
+            logger.debug("[%s] denoise tail -> %d bytes", flow_id, len(pcm_clean))
             sess["lid"].feed(pcm_clean)
             sess["buffer"].extend(pcm_clean)
         language = await sess["lid"].flush()
+        logger.info("[%s] language %s", flow_id, language)
         buffer = bytes(sess["buffer"])
         packets = await sess["compress"].encode(buffer)
+        logger.debug("[%s] compress -> %d packets", flow_id, len(packets))
         first = True
         for pkt in packets:
+            logger.debug("[%s] send packet %d bytes", flow_id, len(pkt))
             await sess["asr"].send(pkt, language if first else None)
             first = False
         await sess["asr"].flush()
@@ -60,6 +71,7 @@ class Orchestrator:
             await sess["ws"].write_message({"type": "lid", "flowId": flow_id, "language": language})
         await sess["ws"].write_message({"type": "end", "flowId": flow_id})
         sess["buffer"].clear()
+        logger.info("[%s] flush done", flow_id)
 
     def close_flow(self, flow_id: str) -> None:
         """Cleanup session state."""

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -1,7 +1,10 @@
 import asyncio
+import logging
 from typing import Any, Dict
 
 from .modules import denoise_client, lid_client, asr_client, vad_client, compress_client
+
+logger = logging.getLogger(__name__)
 
 
 class Orchestrator:
@@ -21,7 +24,7 @@ class Orchestrator:
             "denoise": denoise_client.DenoiseClient(),
             "buffer": bytearray(),
         }
-        print(f"[{flow_id}] start")
+        logger.info("[%s] start", flow_id)
 
     async def feed_pcm(self, flow_id: str, pcm_bytes: bytes, ws) -> None:
         """Process raw PCM: VAD -> Denoise -> LID (buffer only)."""
@@ -66,4 +69,4 @@ class Orchestrator:
             sess["lid"].close()
             sess["denoise"].close()
             sess["compress"].close()
-        print(f"[{flow_id}] closed")
+        logger.info("[%s] closed", flow_id)

--- a/orchestrator/server_ws.py
+++ b/orchestrator/server_ws.py
@@ -3,6 +3,7 @@ import tornado.ioloop
 import tornado.web
 import tornado.websocket
 
+from config import ORCHESTRATOR_PORT
 from .pipeline import Orchestrator
 
 
@@ -42,5 +43,6 @@ def make_app() -> tornado.web.Application:
 
 if __name__ == "__main__":  # pragma: no cover
     app = make_app()
-    app.listen(8000)
+    app.listen(ORCHESTRATOR_PORT)
+    print(f"Orchestrator server listening on port {ORCHESTRATOR_PORT}")
     tornado.ioloop.IOLoop.current().start()

--- a/orchestrator/server_ws.py
+++ b/orchestrator/server_ws.py
@@ -1,10 +1,13 @@
 import json
+import logging
 import tornado.ioloop
 import tornado.web
 import tornado.websocket
 
-from config import ORCHESTRATOR_PORT
+from config import ORCHESTRATOR_PORT, configure_logging
 from .pipeline import Orchestrator
+
+logger = logging.getLogger(__name__)
 
 
 class StreamHandler(tornado.websocket.WebSocketHandler):
@@ -16,7 +19,7 @@ class StreamHandler(tornado.websocket.WebSocketHandler):
 
     async def open(self) -> None:  # pragma: no cover - Tornado callback
         self.buffer = bytearray()
-        print("WS connected")
+        logger.info("WS connected")
 
     async def on_message(self, message):  # pragma: no cover - Tornado callback
         if isinstance(message, bytes):
@@ -42,7 +45,8 @@ def make_app() -> tornado.web.Application:
 
 
 if __name__ == "__main__":  # pragma: no cover
+    configure_logging()
     app = make_app()
     app.listen(ORCHESTRATOR_PORT)
-    print(f"Orchestrator server listening on port {ORCHESTRATOR_PORT}")
+    logger.info("Orchestrator server listening on port %s", ORCHESTRATOR_PORT)
     tornado.ioloop.IOLoop.current().start()

--- a/orchestrator/server_ws.py
+++ b/orchestrator/server_ws.py
@@ -19,21 +19,25 @@ class StreamHandler(tornado.websocket.WebSocketHandler):
 
     async def open(self) -> None:  # pragma: no cover - Tornado callback
         self.buffer = bytearray()
-        logger.info("WS connected")
+        logger.info("WS connected from %s", self.request.remote_ip)
 
     async def on_message(self, message):  # pragma: no cover - Tornado callback
         if isinstance(message, bytes):
+            logger.debug("[%s] WS recv %d bytes", self.flow_id, len(message))
             await self.orchestrator.feed_pcm(self.flow_id, message, self)
         else:
             msg = json.loads(message)
+            logger.debug("WS control %s", msg)
             if msg.get("type") == "start":
                 self.flow_id = msg.get("flowId")
                 await self.orchestrator.start_flow(self.flow_id, self, msg)
             elif msg.get("type") == "flush":
+                logger.info("[%s] WS flush", self.flow_id)
                 await self.orchestrator.flush(self.flow_id)
 
     def on_close(self):  # pragma: no cover - Tornado callback
         if self.flow_id:
+            logger.info("[%s] WS closed", self.flow_id)
             self.orchestrator.close_flow(self.flow_id)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-grpcio
-grpcio-tools
-tornado
-numpy
-soundfile
-sherpa-onnx
-speechbrain
-opuslib
+grpcio==1.74.0
+grpcio-tools==1.74.0
+tornado==6.5.2
+numpy==2.3.2
+soundfile==0.13.1
+sherpa-onnx==1.12.10
+speechbrain==1.0.3
+opuslib==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ soundfile==0.13.1
 sherpa-onnx==1.12.10
 speechbrain==1.0.3
 opuslib==3.0.1
+websockets==12.0

--- a/services/compress/README.md
+++ b/services/compress/README.md
@@ -9,6 +9,7 @@ python -m services.compress.server
 ```
 
 服务默认监听在 `50054` 端口，可通过 `COMPRESS_PORT` 环境变量调整。
+使用仓库根目录的 `./start.sh` 时，本服务会自动启动并将日志写入 `compress.out`。
 
 ## 接口
 

--- a/services/compress/protos/compress_pb2_grpc.py
+++ b/services/compress/protos/compress_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import compress_pb2 as compress__pb2
+from . import compress_pb2 as compress__pb2
 
 GRPC_GENERATED_VERSION = '1.74.0'
 GRPC_VERSION = grpc.__version__

--- a/services/compress/server.py
+++ b/services/compress/server.py
@@ -19,10 +19,13 @@ class CompressServicer(compress_pb2_grpc.CompressServicer):
 
     def Encode(self, request: compress_pb2.PCM, context) -> compress_pb2.Opus:  # type: ignore
         try:
+            logger.debug("recv %d bytes", len(request.data))
             pcm = np.frombuffer(request.data, dtype=np.int16)
             if len(pcm) < self.samples:
+                logger.debug("emit 0 bytes")
                 return compress_pb2.Opus(data=b"")
             pkt = self.encoder.encode(pcm[: self.samples].tobytes(), self.samples)
+            logger.debug("emit %d bytes", len(pkt))
             return compress_pb2.Opus(data=pkt)
         except Exception:
             logger.exception("Compress encoding error")

--- a/services/compress/server.py
+++ b/services/compress/server.py
@@ -3,6 +3,8 @@ from concurrent import futures
 import numpy as np
 from opuslib import Encoder, APPLICATION_AUDIO
 
+from config import COMPRESS_PORT
+
 from .protos import compress_pb2, compress_pb2_grpc
 
 
@@ -23,8 +25,8 @@ class CompressServicer(compress_pb2_grpc.CompressServicer):
 def serve() -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     compress_pb2_grpc.add_CompressServicer_to_server(CompressServicer(), server)
-    server.add_insecure_port("[::]:50054")
-    print("✅ Compress gRPC 服务已启动 (port=50054)")
+    server.add_insecure_port(f"[::]:{COMPRESS_PORT}")
+    print(f"✅ Compress gRPC 服务已启动 (port={COMPRESS_PORT})")
     server.start()
     server.wait_for_termination()
 

--- a/services/compress/server.py
+++ b/services/compress/server.py
@@ -1,9 +1,10 @@
+import logging
 import grpc
 from concurrent import futures
 import numpy as np
 from opuslib import Encoder, APPLICATION_AUDIO
 
-from config import COMPRESS_PORT
+from config import COMPRESS_PORT, configure_logging
 
 from .protos import compress_pb2, compress_pb2_grpc
 
@@ -23,10 +24,12 @@ class CompressServicer(compress_pb2_grpc.CompressServicer):
 
 
 def serve() -> None:
+    configure_logging()
+    logger = logging.getLogger(__name__)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     compress_pb2_grpc.add_CompressServicer_to_server(CompressServicer(), server)
     server.add_insecure_port(f"[::]:{COMPRESS_PORT}")
-    print(f"✅ Compress gRPC 服务已启动 (port={COMPRESS_PORT})")
+    logger.info("Compress gRPC service started (port=%s)", COMPRESS_PORT)
     server.start()
     server.wait_for_termination()
 

--- a/services/compress/server.py
+++ b/services/compress/server.py
@@ -8,6 +8,8 @@ from config import COMPRESS_PORT, configure_logging
 
 from .protos import compress_pb2, compress_pb2_grpc
 
+logger = logging.getLogger(__name__)
+
 
 class CompressServicer(compress_pb2_grpc.CompressServicer):
     def __init__(self, sample_rate: int = 16000, frame_ms: int = 20, bitrate: int = 20000):
@@ -16,16 +18,21 @@ class CompressServicer(compress_pb2_grpc.CompressServicer):
         self.encoder.bitrate = bitrate
 
     def Encode(self, request: compress_pb2.PCM, context) -> compress_pb2.Opus:  # type: ignore
-        pcm = np.frombuffer(request.data, dtype=np.int16)
-        if len(pcm) < self.samples:
+        try:
+            pcm = np.frombuffer(request.data, dtype=np.int16)
+            if len(pcm) < self.samples:
+                return compress_pb2.Opus(data=b"")
+            pkt = self.encoder.encode(pcm[: self.samples].tobytes(), self.samples)
+            return compress_pb2.Opus(data=pkt)
+        except Exception:
+            logger.exception("Compress encoding error")
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details("Compress encoding error")
             return compress_pb2.Opus(data=b"")
-        pkt = self.encoder.encode(pcm[: self.samples].tobytes(), self.samples)
-        return compress_pb2.Opus(data=pkt)
 
 
 def serve() -> None:
     configure_logging()
-    logger = logging.getLogger(__name__)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     compress_pb2_grpc.add_CompressServicer_to_server(CompressServicer(), server)
     server.add_insecure_port(f"[::]:{COMPRESS_PORT}")

--- a/services/denoise/README.md
+++ b/services/denoise/README.md
@@ -9,6 +9,7 @@ python -m services.denoise.server
 ```
 
 服务默认监听 `50053` 端口。
+在仓库根目录运行 `./start.sh` 时，本服务将随其他组件一同启动，日志写入 `denoise.out`。
 
 ## 接口
 

--- a/services/denoise/protos/denoise_pb2_grpc.py
+++ b/services/denoise/protos/denoise_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import denoise_pb2 as denoise__pb2
+from . import denoise_pb2 as denoise__pb2
 
 GRPC_GENERATED_VERSION = '1.74.0'
 GRPC_VERSION = grpc.__version__

--- a/services/denoise/server.py
+++ b/services/denoise/server.py
@@ -14,7 +14,11 @@ class DenoiseServicer(denoise_pb2_grpc.DenoiseServicer):
 
     def Clean(self, request: denoise_pb2.Audio, context):  # type: ignore[override]
         try:
-            return denoise_pb2.Audio(pcm=request.pcm, sample_rate=request.sample_rate)
+            pcm_in = request.pcm
+            logger.debug("recv %d bytes", len(pcm_in))
+            resp = denoise_pb2.Audio(pcm=pcm_in, sample_rate=request.sample_rate)
+            logger.debug("emit %d bytes", len(resp.pcm))
+            return resp
         except Exception:
             logger.exception("Denoise clean error")
             context.set_code(grpc.StatusCode.INTERNAL)

--- a/services/denoise/server.py
+++ b/services/denoise/server.py
@@ -1,7 +1,8 @@
+import logging
 import grpc
 from concurrent import futures
 
-from config import DENOISE_PORT
+from config import DENOISE_PORT, configure_logging
 
 from .protos import denoise_pb2, denoise_pb2_grpc
 
@@ -14,10 +15,12 @@ class DenoiseServicer(denoise_pb2_grpc.DenoiseServicer):
 
 
 def serve() -> None:
+    configure_logging()
+    logger = logging.getLogger(__name__)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     denoise_pb2_grpc.add_DenoiseServicer_to_server(DenoiseServicer(), server)
     server.add_insecure_port(f"[::]:{DENOISE_PORT}")
-    print(f"\u2705 Denoise gRPC service started (port={DENOISE_PORT})")
+    logger.info("Denoise gRPC service started (port=%s)", DENOISE_PORT)
     server.start()
     server.wait_for_termination()
 

--- a/services/denoise/server.py
+++ b/services/denoise/server.py
@@ -1,5 +1,8 @@
 import grpc
 from concurrent import futures
+
+from config import DENOISE_PORT
+
 from .protos import denoise_pb2, denoise_pb2_grpc
 
 
@@ -13,8 +16,8 @@ class DenoiseServicer(denoise_pb2_grpc.DenoiseServicer):
 def serve() -> None:
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     denoise_pb2_grpc.add_DenoiseServicer_to_server(DenoiseServicer(), server)
-    server.add_insecure_port("[::]:50053")
-    print("\u2705 Denoise gRPC service started (port=50053)")
+    server.add_insecure_port(f"[::]:{DENOISE_PORT}")
+    print(f"\u2705 Denoise gRPC service started (port={DENOISE_PORT})")
     server.start()
     server.wait_for_termination()
 

--- a/services/denoise/server.py
+++ b/services/denoise/server.py
@@ -6,17 +6,24 @@ from config import DENOISE_PORT, configure_logging
 
 from .protos import denoise_pb2, denoise_pb2_grpc
 
+logger = logging.getLogger(__name__)
+
 
 class DenoiseServicer(denoise_pb2_grpc.DenoiseServicer):
     """Trivial denoise service that echoes input audio."""
 
     def Clean(self, request: denoise_pb2.Audio, context):  # type: ignore[override]
-        return denoise_pb2.Audio(pcm=request.pcm, sample_rate=request.sample_rate)
+        try:
+            return denoise_pb2.Audio(pcm=request.pcm, sample_rate=request.sample_rate)
+        except Exception:
+            logger.exception("Denoise clean error")
+            context.set_code(grpc.StatusCode.INTERNAL)
+            context.set_details("Denoise clean error")
+            return denoise_pb2.Audio(pcm=b"", sample_rate=request.sample_rate)
 
 
 def serve() -> None:
     configure_logging()
-    logger = logging.getLogger(__name__)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     denoise_pb2_grpc.add_DenoiseServicer_to_server(DenoiseServicer(), server)
     server.add_insecure_port(f"[::]:{DENOISE_PORT}")

--- a/services/lid/README.md
+++ b/services/lid/README.md
@@ -11,7 +11,7 @@
 python -m services.lid.server
 ```
 
-首次启动会自动把模型下载到仓库的 `models/lid/` 目录，以便后续复用。运行在 `start.sh` 中时，日志将输出到 `lid.out`，可通过 `LOG_LEVEL` 环境变量调整详细程度。
+首次启动会自动把模型下载到仓库的 `models/lid/` 目录，以便后续复用。也可在仓库根目录执行 `./start.sh` 统一启动本服务，日志将输出到 `lid.out`，可通过 `LOG_LEVEL` 环境变量调整详细程度。
 
 ## 接口
 

--- a/services/lid/README.md
+++ b/services/lid/README.md
@@ -1,7 +1,9 @@
 # LID 语种识别服务
 
 基于 [SpeechBrain](https://github.com/speechbrain/speechbrain) 提供的
-`lang-id-commonlanguage_ecapa` 预训练模型，实现一个最小化的 gRPC 语种识别服务。
+`lang-id-commonlanguage_ecapa` 预训练模型，通过
+`speechbrain.inference.classifiers.EncoderClassifier` 加载官方 Hugging Face
+权重，实现一个最小化的 gRPC 语种识别服务。
 
 ## 启动
 

--- a/services/lid/README.md
+++ b/services/lid/README.md
@@ -11,7 +11,7 @@
 python -m services.lid.server
 ```
 
-首次启动会自动把模型下载到仓库的 `models/lid/` 目录，以便后续复用。
+首次启动会自动把模型下载到仓库的 `models/lid/` 目录，以便后续复用。运行在 `start.sh` 中时，日志将输出到 `lid.out`，可通过 `LOG_LEVEL` 环境变量调整详细程度。
 
 ## 接口
 

--- a/services/lid/protos/lid_pb2_grpc.py
+++ b/services/lid/protos/lid_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import lid_pb2 as lid__pb2
+from . import lid_pb2 as lid__pb2
 
 GRPC_GENERATED_VERSION = '1.63.0'
 GRPC_VERSION = grpc.__version__

--- a/services/lid/server.py
+++ b/services/lid/server.py
@@ -7,7 +7,7 @@ import wave
 from pathlib import Path
 
 import grpc
-from speechbrain.pretrained import LanguageID
+from speechbrain.inference.classifiers import EncoderClassifier
 
 from .protos import lid_pb2, lid_pb2_grpc
 
@@ -15,7 +15,7 @@ from .protos import lid_pb2, lid_pb2_grpc
 MODEL_DIR = Path(__file__).resolve().parents[2] / "models" / "lid"
 
 # Load model at module import so it can be shared across requests.
-lid_model = LanguageID.from_hparams(
+lid_model = EncoderClassifier.from_hparams(
     source="speechbrain/lang-id-commonlanguage_ecapa", savedir=str(MODEL_DIR)
 )
 
@@ -38,8 +38,8 @@ class LIDServicer(lid_pb2_grpc.LIDServicer):
             f.write(wav_bytes)
             tmp_path = f.name
         try:
-            out_prob, score, language = lid_model.classify_file(tmp_path)
-            return lid_pb2.LIDResponse(language=language, score=float(score))
+            out_prob, score, index, language = lid_model.classify_file(tmp_path)
+            return lid_pb2.LIDResponse(language=language[0], score=float(score))
         finally:
             os.remove(tmp_path)
 

--- a/services/lid/server.py
+++ b/services/lid/server.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import grpc
 from speechbrain.inference.classifiers import EncoderClassifier
 
+from config import LID_PORT
+
 from .protos import lid_pb2, lid_pb2_grpc
 
 # Persist model weights under repository's models directory
@@ -47,10 +49,10 @@ class LIDServicer(lid_pb2_grpc.LIDServicer):
 def serve() -> None:
     server = grpc.aio.server()
     lid_pb2_grpc.add_LIDServicer_to_server(LIDServicer(), server)
-    server.add_insecure_port("[::]:50052")
+    server.add_insecure_port(f"[::]:{LID_PORT}")
     loop = asyncio.get_event_loop()
     loop.run_until_complete(server.start())
-    print("LID gRPC server started on port 50052")
+    print(f"LID gRPC server started on port {LID_PORT}")
     loop.run_until_complete(server.wait_for_termination())
 
 

--- a/services/lid/server.py
+++ b/services/lid/server.py
@@ -4,6 +4,7 @@ import io
 import os
 import tempfile
 import wave
+from pathlib import Path
 
 import grpc
 from speechbrain.pretrained import LanguageID
@@ -11,13 +12,11 @@ from speechbrain.pretrained import LanguageID
 from .protos import lid_pb2, lid_pb2_grpc
 
 # Persist model weights under repository's models directory
-MODEL_DIR = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "models", "lid"
-)
+MODEL_DIR = Path(__file__).resolve().parents[2] / "models" / "lid"
 
 # Load model at module import so it can be shared across requests.
 lid_model = LanguageID.from_hparams(
-    source="speechbrain/lang-id-commonlanguage_ecapa", savedir=MODEL_DIR
+    source="speechbrain/lang-id-commonlanguage_ecapa", savedir=str(MODEL_DIR)
 )
 
 

--- a/services/lid/server.py
+++ b/services/lid/server.py
@@ -1,6 +1,7 @@
 """Minimal gRPC LID service using SpeechBrain."""
 import asyncio
 import io
+import logging
 import os
 import tempfile
 import wave
@@ -9,7 +10,7 @@ from pathlib import Path
 import grpc
 from speechbrain.inference.classifiers import EncoderClassifier
 
-from config import LID_PORT
+from config import LID_PORT, configure_logging
 
 from .protos import lid_pb2, lid_pb2_grpc
 
@@ -47,12 +48,14 @@ class LIDServicer(lid_pb2_grpc.LIDServicer):
 
 
 def serve() -> None:
+    configure_logging()
+    logger = logging.getLogger(__name__)
     server = grpc.aio.server()
     lid_pb2_grpc.add_LIDServicer_to_server(LIDServicer(), server)
     server.add_insecure_port(f"[::]:{LID_PORT}")
     loop = asyncio.get_event_loop()
     loop.run_until_complete(server.start())
-    print(f"LID gRPC server started on port {LID_PORT}")
+    logger.info("LID gRPC server started on port %s", LID_PORT)
     loop.run_until_complete(server.wait_for_termination())
 
 

--- a/services/lid/server.py
+++ b/services/lid/server.py
@@ -52,16 +52,15 @@ class LIDServicer(lid_pb2_grpc.LIDServicer):
             os.remove(tmp_path)
 
 
-def serve() -> None:
+async def serve() -> None:
     configure_logging()
     server = grpc.aio.server()
     lid_pb2_grpc.add_LIDServicer_to_server(LIDServicer(), server)
     server.add_insecure_port(f"[::]:{LID_PORT}")
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(server.start())
-    logger.info("LID gRPC server started on port %s", LID_PORT)
-    loop.run_until_complete(server.wait_for_termination())
+    await server.start()
+    logger.info("LID gRPC server started on %s", LID_PORT)
+    await server.wait_for_termination()
 
 
 if __name__ == "__main__":
-    serve()
+    asyncio.run(serve())

--- a/services/vad/README.md
+++ b/services/vad/README.md
@@ -9,6 +9,7 @@ python -m services.vad.server
 ```
 
 首次运行会自动把 `ten-vad.onnx` 模型下载到仓库根目录的 `models/` 目录，后续可复用。服务默认监听 `9001` 端口，可通过环境变量 `VAD_PORT` 覆盖。
+在仓库根目录执行 `./start.sh` 时，本服务会自动启动并将日志写入 `vad.out`。
 
 ## 交互流程
 

--- a/services/vad/protos/vad_pb2_grpc.py
+++ b/services/vad/protos/vad_pb2_grpc.py
@@ -3,7 +3,7 @@
 import grpc
 import warnings
 
-import vad_pb2 as vad__pb2
+from . import vad_pb2 as vad__pb2
 
 GRPC_GENERATED_VERSION = '1.74.0'
 GRPC_VERSION = grpc.__version__

--- a/services/vad/server.py
+++ b/services/vad/server.py
@@ -2,14 +2,13 @@
 # -*- coding: utf-8 -*-
 """gRPC server exposing the VAD session."""
 
-import os
 import asyncio
 import grpc
 
+from config import VAD_PORT
+
 from .vad import make_vad_session, pcm16_bytes_to_float32
 from .protos import vad_pb2, vad_pb2_grpc
-
-VAD_PORT = int(os.environ.get("VAD_PORT", "9001"))
 
 
 class VadServicer(vad_pb2_grpc.VoiceActivityServicer):

--- a/services/vad/server.py
+++ b/services/vad/server.py
@@ -11,26 +11,30 @@ from config import VAD_PORT, configure_logging
 from .vad import make_vad_session, pcm16_bytes_to_float32
 from .protos import vad_pb2, vad_pb2_grpc
 
+logger = logging.getLogger(__name__)
 
 class VadServicer(vad_pb2_grpc.VoiceActivityServicer):
     async def Stream(self, request_iterator, context):
         sess = make_vad_session()
-        async for frame in request_iterator:
-            if frame.HasField("pcm"):
-                sess.accept_f32(pcm16_bytes_to_float32(frame.pcm.data))
-                out = sess.pop_pcm()
-                if out:
-                    yield vad_pb2.ServerFrame(pcm=vad_pb2.Pcm(data=out))
-            elif frame.HasField("flush"):
-                out = sess.flush_pcm()
-                if out:
-                    yield vad_pb2.ServerFrame(pcm=vad_pb2.Pcm(data=out))
-                break
+        try:
+            async for frame in request_iterator:
+                if frame.HasField("pcm"):
+                    sess.accept_f32(pcm16_bytes_to_float32(frame.pcm.data))
+                    out = sess.pop_pcm()
+                    if out:
+                        yield vad_pb2.ServerFrame(pcm=vad_pb2.Pcm(data=out))
+                elif frame.HasField("flush"):
+                    out = sess.flush_pcm()
+                    if out:
+                        yield vad_pb2.ServerFrame(pcm=vad_pb2.Pcm(data=out))
+                    break
+        except Exception:
+            logger.exception("VAD stream error")
+            await context.abort(grpc.StatusCode.INTERNAL, "VAD stream error")
 
 
 async def serve() -> None:
     configure_logging()
-    logger = logging.getLogger(__name__)
     server = grpc.aio.server()
     vad_pb2_grpc.add_VoiceActivityServicer_to_server(VadServicer(), server)
     server.add_insecure_port(f"[::]:{VAD_PORT}")

--- a/services/vad/server.py
+++ b/services/vad/server.py
@@ -3,9 +3,10 @@
 """gRPC server exposing the VAD session."""
 
 import asyncio
+import logging
 import grpc
 
-from config import VAD_PORT
+from config import VAD_PORT, configure_logging
 
 from .vad import make_vad_session, pcm16_bytes_to_float32
 from .protos import vad_pb2, vad_pb2_grpc
@@ -28,11 +29,13 @@ class VadServicer(vad_pb2_grpc.VoiceActivityServicer):
 
 
 async def serve() -> None:
+    configure_logging()
+    logger = logging.getLogger(__name__)
     server = grpc.aio.server()
     vad_pb2_grpc.add_VoiceActivityServicer_to_server(VadServicer(), server)
     server.add_insecure_port(f"[::]:{VAD_PORT}")
     await server.start()
-    print(f"VAD gRPC server listening on {VAD_PORT}")
+    logger.info("VAD gRPC server listening on %s", VAD_PORT)
     await server.wait_for_termination()
 
 

--- a/services/vad/vad.py
+++ b/services/vad/vad.py
@@ -1,6 +1,7 @@
 import os
 import io
 from collections import deque
+from pathlib import Path
 from typing import List, Optional
 
 import numpy as np
@@ -17,10 +18,8 @@ VAD_PAD_END_MS = int(os.environ.get("VAD_PAD_END_MS", "80"))
 
 
 def _default_model_path() -> str:
-    return os.environ.get(
-        "VAD_MODEL",
-        os.path.join(os.path.dirname(__file__), "..", "..", "models", "ten-vad.onnx"),
-    )
+    base = Path(__file__).resolve().parents[2] / "models" / "ten-vad.onnx"
+    return os.environ.get("VAD_MODEL", str(base))
 
 
 def pcm16_bytes_to_float32(pcm: bytes) -> np.ndarray:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Batch start script for ASR service components
+set -euo pipefail
+cd "$(dirname "$0")"
+nohup python -m services.vad.server > vad.out &
+nohup python -m services.denoise.server > denoise.out &
+nohup python -m services.lid.server > lid.out &
+nohup python -m services.compress.server > compress.out &
+nohup python -m orchestrator.server_ws > server.out &

--- a/start.sh
+++ b/start.sh
@@ -2,8 +2,8 @@
 # Batch start script for ASR service components
 set -euo pipefail
 cd "$(dirname "$0")"
-nohup python -m services.vad.server > vad.out &
-nohup python -m services.denoise.server > denoise.out &
-nohup python -m services.lid.server > lid.out &
-nohup python -m services.compress.server > compress.out &
-nohup python -m orchestrator.server_ws > server.out &
+nohup python -m services.vad.server > vad.out 2>&1 &
+nohup python -m services.denoise.server > denoise.out 2>&1 &
+nohup python -m services.lid.server > lid.out 2>&1 &
+nohup python -m services.compress.server > compress.out 2>&1 &
+nohup python -m orchestrator.server_ws > server.out 2>&1 &

--- a/tests/send_only.py
+++ b/tests/send_only.py
@@ -1,9 +1,11 @@
 import asyncio, numpy as np, soundfile as sf, grpc
 from pathlib import Path
+
+from config import VAD_PORT
 from services.vad.protos import vad_pb2, vad_pb2_grpc
 
 
-async def send_only(target="localhost:9001", wav_path: str | None = None):
+async def send_only(target=f"localhost:{VAD_PORT}", wav_path: str | None = None):
     wav_path = wav_path or str(Path(__file__).with_name("test.wav"))
     y, sr = sf.read(wav_path, dtype="float32")
     if y.ndim > 1:

--- a/tests/send_only.py
+++ b/tests/send_only.py
@@ -1,4 +1,7 @@
-import asyncio, numpy as np, soundfile as sf, grpc
+"""Send a PCM WAV to the VAD service and log responses/errors."""
+
+import asyncio, logging
+import numpy as np, soundfile as sf, grpc
 from pathlib import Path
 
 from config import VAD_PORT
@@ -6,31 +9,42 @@ from services.vad.protos import vad_pb2, vad_pb2_grpc
 
 
 async def send_only(target=f"localhost:{VAD_PORT}", wav_path: str | None = None):
+    logging.basicConfig(level="INFO")
+    logger = logging.getLogger(__name__)
     wav_path = wav_path or str(Path(__file__).with_name("test.wav"))
-    y, sr = sf.read(wav_path, dtype="float32")
-    if y.ndim > 1:
-        y = y.mean(axis=1)
-    pcm = (np.clip(y, -1, 1) * 32767).astype(np.int16).tobytes()
-    step = int(16000 * 0.02) * 2  # 20ms frames
+    try:
+        y, sr = sf.read(wav_path, dtype="float32")
+        if y.ndim > 1:
+            y = y.mean(axis=1)
+        pcm = (np.clip(y, -1, 1) * 32767).astype(np.int16).tobytes()
+        step = int(16000 * 0.02) * 2  # 20ms frames
 
-    chan = grpc.aio.insecure_channel(target)
-    stub = vad_pb2_grpc.VoiceActivityStub(chan)
-    stream = stub.Stream()
-    await stream.write(vad_pb2.ClientFrame(start=vad_pb2.Start(flow_id="test", sample_rate=16000)))
-    for i in range(0, len(pcm), step):
-        await stream.write(vad_pb2.ClientFrame(pcm=vad_pb2.Pcm(data=pcm[i:i+step])))
-        while True:
-            try:
-                resp = await asyncio.wait_for(stream.read(), timeout=0)
-                if resp.pcm.data:
-                    pass
-            except asyncio.TimeoutError:
-                break
-    await stream.write(vad_pb2.ClientFrame(flush=vad_pb2.Flush()))
-    await stream.done_writing()
-    async for _ in stream:
-        pass
-    await chan.close()
+        chan = grpc.aio.insecure_channel(target)
+        stub = vad_pb2_grpc.VoiceActivityStub(chan)
+        stream = stub.Stream()
+        await stream.write(
+            vad_pb2.ClientFrame(start=vad_pb2.Start(flow_id="test", sample_rate=16000))
+        )
+        for i in range(0, len(pcm), step):
+            await stream.write(
+                vad_pb2.ClientFrame(pcm=vad_pb2.Pcm(data=pcm[i : i + step]))
+            )
+            while True:
+                try:
+                    resp = await asyncio.wait_for(stream.read(), timeout=0)
+                    if resp.pcm.data:
+                        logger.info("received %d bytes", len(resp.pcm.data))
+                except asyncio.TimeoutError:
+                    break
+        await stream.write(vad_pb2.ClientFrame(flush=vad_pb2.Flush()))
+        await stream.done_writing()
+        async for _ in stream:
+            pass
+        await chan.close()
+    except grpc.RpcError as e:
+        logger.error("gRPC error: %s", e)
+    except Exception:
+        logger.exception("send_only failed")
 
 
 if __name__ == "__main__":

--- a/tests/send_only.py
+++ b/tests/send_only.py
@@ -16,18 +16,29 @@ async def send_only(target=f"localhost:{VAD_PORT}", wav_path: str | None = None)
         y, sr = sf.read(wav_path, dtype="float32")
         if y.ndim > 1:
             y = y.mean(axis=1)
+        logger.info("loaded %s (%d samples @ %d Hz)", wav_path, y.size, sr)
         pcm = (np.clip(y, -1, 1) * 32767).astype(np.int16).tobytes()
         step = int(16000 * 0.02) * 2  # 20ms frames
 
         chan = grpc.aio.insecure_channel(target)
+        try:
+            await asyncio.wait_for(chan.channel_ready(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.error("gRPC channel %s not ready", target)
+            return
         stub = vad_pb2_grpc.VoiceActivityStub(chan)
         stream = stub.Stream()
 
         async def read_responses():
             try:
-                async for resp in stream:
+                while True:
+                    resp = await asyncio.wait_for(stream.read(), timeout=5.0)
+                    if resp is grpc.aio.EOF:
+                        break
                     if resp.pcm.data:
                         logger.info("received %d bytes", len(resp.pcm.data))
+            except asyncio.TimeoutError:
+                logger.error("timeout waiting for server response")
             except grpc.RpcError as e:
                 logger.error("stream read error: %s", e)
 
@@ -37,9 +48,9 @@ async def send_only(target=f"localhost:{VAD_PORT}", wav_path: str | None = None)
             vad_pb2.ClientFrame(start=vad_pb2.Start(flow_id="test", sample_rate=16000))
         )
         for i in range(0, len(pcm), step):
-            await stream.write(
-                vad_pb2.ClientFrame(pcm=vad_pb2.Pcm(data=pcm[i : i + step]))
-            )
+            chunk = pcm[i : i + step]
+            logger.debug("sending %d bytes", len(chunk))
+            await stream.write(vad_pb2.ClientFrame(pcm=vad_pb2.Pcm(data=chunk)))
 
         await stream.write(vad_pb2.ClientFrame(flush=vad_pb2.Flush()))
         await stream.done_writing()

--- a/tests/send_to_orchestrator.py
+++ b/tests/send_to_orchestrator.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+send_to_orchestrator.py
+将本地 WAV(16k/mono/PCM16) 流式发送到“编排器”的 WebSocket 入口，并打印返回事件。
+用法示例：
+    python send_to_orchestrator.py --ws ws://127.0.0.1:9000/ws/stream --input input.wav --chunk-ms 30 --realtime
+依赖：
+    pip install websockets
+"""
+import argparse
+import asyncio
+import json
+import time
+import wave
+from pathlib import Path
+
+import websockets
+
+
+def read_wav_raw(path: Path):
+    with wave.open(str(path), "rb") as wf:
+        nch = wf.getnchannels()
+        sr = wf.getframerate()
+        sw = wf.getsampwidth()
+        nframes = wf.getnframes()
+        raw = wf.readframes(nframes)
+    return raw, sr, nch, sw
+
+
+def chunk_bytes(raw: bytes, sr: int, nch: int, sampwidth: int, chunk_ms: int):
+    # 每片样本数
+    samples_per_chunk = int(sr * chunk_ms / 1000)
+    # 每片字节数
+    bytes_per_chunk = samples_per_chunk * nch * sampwidth
+    for i in range(0, len(raw), bytes_per_chunk):
+        yield raw[i:i + bytes_per_chunk]
+
+
+async def receiver(ws, save_binary_prefix: str = "recv"):
+    """
+    并行接收服务端事件：若为文本帧（JSON），解析打印；若为二进制帧，简单落盘（若检测到WAV头）。
+    """
+    bin_idx = 0
+    try:
+        async for msg in ws:
+            ts = time.strftime("%H:%M:%S")
+            if isinstance(msg, (bytes, bytearray)):
+                # 简单二进制处理：若像 WAV（'RIFF' 开头），则保存
+                header = bytes(msg[:4])
+                if header == b"RIFF":
+                    out = f"{save_binary_prefix}_{bin_idx:02d}.wav"
+                    Path(out).write_bytes(msg)
+                    print(f"[{ts}] [binary] -> saved WAV: {out} ({len(msg)} bytes)")
+                else:
+                    out = f"{save_binary_prefix}_{bin_idx:02d}.bin"
+                    Path(out).write_bytes(msg)
+                    print(f"[{ts}] [binary] -> saved BIN: {out} ({len(msg)} bytes)")
+                bin_idx += 1
+            else:
+                # 文本帧：尽量按 JSON 打印关键信息
+                try:
+                    data = json.loads(msg)
+                    etype = data.get("type")
+                    if etype in ("ack", "lid", "asr_partial", "asr_final", "record_url", "metrics", "error", "end"):
+                        print(f"[{ts}] [{etype}] {json.dumps(data, ensure_ascii=False)}")
+                    else:
+                        print(f"[{ts}] [event] {json.dumps(data, ensure_ascii=False)}")
+                except Exception:
+                    print(f"[{ts}] [text] {msg}")
+    except websockets.ConnectionClosedOK:
+        print("[receiver] connection closed normally")
+    except websockets.ConnectionClosedError as e:
+        print(f"[receiver] connection closed with error: {e}")
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ws", required=True, help="编排器 WebSocket 入口，如 ws://127.0.0.1:9000/ws/stream")
+    ap.add_argument("--input", required=True, help="输入 WAV (16k/mono/PCM16)")
+    ap.add_argument("--chunk-ms", type=int, default=30, help="分片时长，默认30ms")
+    ap.add_argument("--realtime", action="store_true", help="按真实时间节奏发送（每片sleep chunk_ms）")
+    ap.add_argument("--stream-name", default="test-stream", help="可选：流名/会话名")
+    args = ap.parse_args()
+
+    wav_path = Path(args.input)
+    raw, sr, nch, sw = read_wav_raw(wav_path)
+
+    # 基础校验：16k / mono / 16-bit PCM
+    if sr != 16000 or nch != 1 or sw != 2:
+        raise ValueError(
+            f"需要 16k/mono/PCM16，实际为 sr={sr}, nch={nch}, sampwidth={sw}。"
+            f"请先转换：ffmpeg -i in.wav -ar 16000 -ac 1 -sample_fmt s16 out.wav"
+        )
+
+    # 连接编排器
+    async with websockets.connect(args.ws, max_size=None) as ws:
+        # 启动接收任务
+        recv_task = asyncio.create_task(receiver(ws))
+
+        # 1) 发送 start 控制帧（文本 JSON）
+        start_msg = {
+            "type": "start",
+            "format": "pcm16",  # 也可支持 "opus"（若你的编排器已接入 Opus）
+            "sr": sr,
+            "channels": nch,
+            "stream": args.stream_name,
+            "metadata": {
+                "client": "send_to_orchestrator.py",
+                "ts": int(time.time()),
+            },
+            # 视你的后端实现，也可增加 no_reply/use_accelerate等自定义字段
+        }
+        await ws.send(json.dumps(start_msg))
+        print(f"[start] -> {start_msg}")
+
+        # 2) 连续发送音频二进制帧
+        bytes_sent = 0
+        chunk_count = 0
+        for b in chunk_bytes(raw, sr, nch, sw, args.chunk_ms):
+            if not b:
+                continue
+            await ws.send(b)  # 二进制帧
+            bytes_sent += len(b)
+            chunk_count += 1
+            if args.realtime:
+                await asyncio.sleep(args.chunk_ms / 1000.0)
+
+        print(f"[audio] sent chunks={chunk_count}, bytes={bytes_sent}")
+
+        # 3) 发送 flush（文本帧）
+        await ws.send(json.dumps({"type": "flush"}))
+        print("[flush] sent")
+
+        # 4) 等待“end”事件或超时后关闭（这里简单等待几秒）
+        try:
+            await asyncio.wait_for(recv_task, timeout=10.0)
+        except asyncio.TimeoutError:
+            print("[wait] timeout; closing connection")
+        finally:
+            await ws.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- Add `start.sh` to launch VAD, denoise, language ID, compression and orchestrator services in one command
- Make model path resolution in VAD and LID services relative to repository root
- Pin dependencies to explicit versions in `requirements.txt`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad4a8d610883269363f4dd9c2a22f8